### PR TITLE
Fixed loading masters on update.

### DIFF
--- a/NewPlatform.Flexberry.ORM.ODataService/Controllers/DataObjectController.ModifyData.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Controllers/DataObjectController.ModifyData.cs
@@ -497,7 +497,8 @@
             {
                 DataObject dataObjectFromCache = _dataObjectCache.GetLivingDataObject(objType, keyValue);
 
-                if (dataObjectFromCache != null)
+                // Берем из кэша только загруженные объекты.
+                if (dataObjectFromCache != null && (bool?)dataObjectFromCache.DynamicProperties[nameof(ReturnDataObject)] == true)
                 {
                     if (!_newDataObjects.ContainsKey(dataObjectFromCache))
                     {
@@ -517,6 +518,10 @@
                 if (dobjs.Length == 1)
                 {
                     DataObject dataObject = dobjs[0];
+
+                    // Помечаем объект загруженным.
+                    dataObject.DynamicProperties[nameof(ReturnDataObject)] = true;
+
                     _newDataObjects.Add(dataObject, false);
                     return dataObject;
                 }


### PR DESCRIPTION
При вычитке объектов, которые должны отправиться на обновление, из-за #42 был нарушен "жадный" метод чтения, и некоторые мастера оказывались загружены только первичным ключом, что есть breaking change. Откатываю изящным костылём.