### PR TITLE
Тест для ошибки, когда $filter состоит из предиката any, связанного с другим условием

### DIFF
--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/FilterByMasterDetailComplexPredicateTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/FilterByMasterDetailComplexPredicateTest.cs
@@ -1,0 +1,73 @@
+﻿namespace NewPlatform.Flexberry.ORM.ODataService.Tests.CRUD.Read
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.KeyGen;
+    using ICSSoft.STORMNET.Windows.Forms;
+    using NewPlatform.Flexberry.ORM.ODataService.Tests.Extensions;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    using Xunit;
+
+    /// <summary>
+    /// Unit-test class for filtering data through OData service by master details fields.
+    /// </summary>
+    public class FilterByMasterDetailComplexPredicateTest : BaseODataServiceIntegratedTest
+    {
+        /// <summary>
+        /// Tests filtering data by master field.
+        /// </summary>
+        [Fact]
+        public void TestFilterByMasterDetailComplexPredicate()
+        {
+            ActODataService(args =>
+            {
+                // Arrange.
+                Медведь медведь1 = new Медведь() { ПорядковыйНомер = 1,  };
+                Медведь медведь2 = new Медведь() { ПорядковыйНомер = 2 };
+
+                Лес лес1 = new Лес() { Название = "Шишкин" };
+                Лес лес2 = new Лес() { Название = "Ёжкин" };
+
+                Берлога берлога1 = new Берлога() { Наименование = "Берлога 1", ЛесРасположения = лес1 };
+                Берлога берлога2 = new Берлога() { Наименование = "Берлога 2", ЛесРасположения = лес1 };
+                Берлога берлога3 = new Берлога() { Наименование = "Берлога 3", ЛесРасположения = лес2 };
+                Берлога берлога4 = new Берлога() { Наименование = "Берлога 4", ЛесРасположения = лес2 };
+
+                медведь1.Берлога.AddRange(берлога1, берлога2);
+                медведь2.Берлога.AddRange(берлога3, берлога4);
+
+                Блоха блоха1 = new Блоха() { Кличка = "Блоха 1", МедведьОбитания = медведь1 };
+                Блоха блоха2 = new Блоха() { Кличка = "Блоха 2", МедведьОбитания = медведь2 };
+                Блоха блоха3 = new Блоха() { Кличка = "Блоха 3" };
+                Блоха блоха4 = new Блоха() { Кличка = "Блоха 4", МедведьОбитания = медведь1 };
+
+                DataObject[] newDataObjects = new DataObject[] { лес1, лес2, медведь1, медведь2, берлога1, берлога2, берлога3, берлога4, блоха1, блоха2, блоха3, блоха4 };
+
+                args.DataService.UpdateObjects(ref newDataObjects);
+                ExternalLangDef.LanguageDef.DataService = args.DataService;
+
+                string лес1Pk = ((KeyGuid)лес1.__PrimaryKey).Guid.ToString("D");
+                string медведь1Pk = ((KeyGuid)медведь1.__PrimaryKey).Guid.ToString("D");
+
+                string requestUrl = string.Format(
+                "http://localhost/odata/{0}?$filter={1}",
+                args.Token.Model.GetEdmEntitySet(typeof(Блоха)).Name,
+                "(МедведьОбитания/Берлога/any(f:(f/Наименование eq 'Берлога 1') and ( ( not(f/ЛесРасположения/Площадь eq 123)) or (f/ЛесРасположения/__PrimaryKey eq " + лес1Pk + ") )) ) and (МедведьОбитания/__PrimaryKey eq " + медведь1Pk + ")");
+
+                using (var response = args.HttpClient.GetAsync(requestUrl).Result)
+                {
+                    string receivedStr = response.Content.ReadAsStringAsync().Result.Beautify();
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    Dictionary<string, object> receivedDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(receivedStr);
+                    Assert.Equal(2, ((JArray)receivedDict["value"]).Count);
+                }
+            });
+        }
+    }
+}

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
@@ -265,6 +265,7 @@
     <Compile Include="CRUD\Read\Excel\ExcelExportTest.cs" />
     <Compile Include="CRUD\Read\Excel\ExportExcel.cs" />
     <Compile Include="CRUD\Read\Excel\SpreadsheetCustomizer.cs" />
+    <Compile Include="CRUD\Read\FilterByMasterDetailComplexPredicateTest.cs" />
     <Compile Include="CRUD\Read\FilterByMasterDetailFieldTest.cs" />
     <Compile Include="CRUD\Read\FilterByPseudoDetailFieldTest.cs" />
     <Compile Include="CRUD\Read\ReferenceToMasterTest.cs" />


### PR DESCRIPTION
В эмбере понадобилось сделать ComplexPredicate, внутри которого лежит DetailPredicate и SimplePredicate. Обнаружил, что Flexberry ODataService возвращает ошибку на такие запросы (когда $filter состоит из оператора any/all, связанного с каким-то другим условием через И/ИЛИ).

Сама odata позволяет делать такие запросы (например: http://services.odata.org/TripPinRESTierService/(S(3mslpb2bc0k5ufk24olpghzx))/People?$filter=Trips/all(f:f/Budget eq 3000) and not(UserName eq 'russellwhyte'))

В ПР загрузил тест, который демонстрирует ошибку.
