### PR TITLE
Mapping only selected properties on getting objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 4. Use common DataObjectCache for all sql queries per http request.
 5. [BREAKINGCHANGE] Details BS not apply changes in agregator. Use BS for agregator when details changed.
 6. Refactor `DataObjectControllerActivator` to simplify overriding DOC initialization.
+7. Mapping only selected properties on getting objects.
 
 ### Fixed
 

--- a/NewPlatform.Flexberry.ORM.ODataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ODataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.ODataService</id>
-    <version>5.1.0-beta13</version>
+    <version>5.1.0-beta14</version>
     <title>Flexberry ORM ODataService</title>
     <authors>New Platform Ltd.</authors>
     <owners>New Platform Ltd.</owners>
@@ -25,6 +25,7 @@
       4. Use common DataObjectCache for all sql queries per http request.
       5. [BREAKINGCHANGE] Details BS not apply changes in agregator. Use BS for agregator when details changed.
       6. Refactor `DataObjectControllerActivator` to simplify overriding DOC initialization.
+      7. Mapping only selected properties on getting objects.
 
       Fixed
       1. Fix error with POST request and header "Prefer".


### PR DESCRIPTION
Добавление проверки `selectedProperties.ContainsKey(prop.Name)` (ln 549) позвляет исключить свойства, которые отсутствуют в $select из преобразования dataobject -> edm.

Эти свойства не требуются в edm объекте, т.к. они не будут сериализованы.