### PR TITLE
Исправление ошибок метаданных

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1-beta01`.
 
 ### Fixed
+1. Fixed problem with metadata when inheritance and PublishName is used (for Net Standart 2.0, Net Core 3.1, Net 6.0, Net 7.0).
 
 ## [7.1.0] - 2023.04.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1-beta01`.
 
 ### Fixed
-1. Fixed problem with metadata when inheritance and PublishName is used (for Net Standart 2.0, Net Core 3.1, Net 6.0, Net 7.0).
+1. Fixed problem with metadata when inheritance and PublishName is used.
 
 ## [7.1.0] - 2023.04.12
 

--- a/NewPlatform.Flexberry.ORM.ODataService.Files/NewPlatform.Flexberry.ORM.ODataService.Files.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService.Files/NewPlatform.Flexberry.ORM.ODataService.Files.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataService.WebApi/NewPlatform.Flexberry.ORM.ODataService.WebApi.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService.WebApi/NewPlatform.Flexberry.ORM.ODataService.WebApi.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.LockService" Version="3.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ODataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.ODataService</id>
-    <version>7.1.1-beta01</version>
+    <version>7.1.1-beta02</version>
     <title>Flexberry ORM ODataService</title>
     <authors>New Platform Ltd.</authors>
     <owners>New Platform Ltd.</owners>
@@ -16,7 +16,7 @@
 		1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1-beta01`.
 
 		Fixed
-		1. Fixed problem with metadata when inheritance and PublishName is used (for Net Standart 2.0, Net Core 3.1, Net 6.0, Net 7.0).
+		1. Fixed problem with metadata when inheritance and PublishName is used.
 	</releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM OData ODataService</tags>

--- a/NewPlatform.Flexberry.ORM.ODataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ODataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.ODataService</id>
-    <version>7.1.0</version>
+    <version>7.1.1-beta01</version>
     <title>Flexberry ORM ODataService</title>
     <authors>New Platform Ltd.</authors>
     <owners>New Platform Ltd.</owners>
@@ -13,7 +13,10 @@
     <description>Flexberry ORM OData Service Package.</description>
     <releaseNotes>
 		Changed
-		1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.0`.
+		1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1-beta01`.
+
+		Fixed
+		1. Fixed problem with metadata when inheritance and PublishName is used (for Net Standart 2.0, Net Core 3.1, Net 6.0, Net 7.0).
 	</releaseNotes>
     <copyright>Copyright New Platform Ltd 2023</copyright>
     <tags>Flexberry ORM OData ODataService</tags>

--- a/NewPlatform.Flexberry.ORM.ODataService/Expressions/EdmLibHelpers.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Expressions/EdmLibHelpers.cs
@@ -351,7 +351,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Expressions
 
         private static string EdmFullName(this Type clrType)
         {
-            return string.IsNullOrEmpty(clrType.Namespace) ? clrType.EdmName() : string.Format(CultureInfo.InvariantCulture, "{0}.{1}", clrType.Namespace, clrType.EdmName());
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", clrType.Namespace, clrType.EdmName());
         }
 
         private static IEdmPrimitiveType GetPrimitiveType(EdmPrimitiveTypeKind primitiveKind)

--- a/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataApplicationBuilderExtensions.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataApplicationBuilderExtensions.cs
@@ -78,8 +78,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
                     await next();
 
                     responseBodyStream.Seek(0, SeekOrigin.Begin);
-                    using StreamReader sr = new StreamReader(responseBodyStream);
-                    var responseBody = sr.ReadToEnd();
+                    var responseBody = new StreamReader(responseBodyStream).ReadToEnd();
 
                     //Modify the response in some way.
                     if (context.Response.ContentType != null &&

--- a/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataApplicationBuilderExtensions.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataApplicationBuilderExtensions.cs
@@ -2,10 +2,14 @@
 namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
 {
     using System;
+    using System.IO;
+    using System.Net.Mime;
+    using System.Threading.Tasks;
     using Microsoft.AspNet.OData;
     using Microsoft.AspNet.OData.Common;
     using Microsoft.AspNet.OData.Extensions;
     using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Routing;
     using NewPlatform.Flexberry.ORM.ODataService.Middleware;
 
@@ -30,6 +34,11 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
 
             VerifyODataServiceIsRegistered(app);
 
+            app.Use(async (context, next) =>
+            {
+                await RewriteResponse(context, next);
+            });
+
             return app
                 .UseODataBatching()
                 .UseMiddleware<RequestHeadersHookMiddleware>()
@@ -46,6 +55,57 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
             if (app.ApplicationServices.GetService(typeof(IPerRouteContainer)) == null)
             {
                 throw Error.InvalidOperation(SRResources.MissingODataServices, nameof(IPerRouteContainer));
+            }
+        }
+
+        /// <summary>
+        /// Removing of extra symbols from response.
+        /// </summary>
+        /// <param name="context">Context of request.</param>
+        /// <param name="next">Next middleware.</param>
+        /// <returns>Formed task.</returns>
+        public static async Task RewriteResponse(HttpContext context, Func<Task> next)
+        {
+            using (var responseBodyStream = new MemoryStream())
+            {
+                var bodyStream = context.Response.Body;
+
+                try
+                {
+                    context.Response.Body = responseBodyStream;
+
+                    await next();
+
+                    responseBodyStream.Seek(0, SeekOrigin.Begin);
+                    var responseBody = new StreamReader(responseBodyStream).ReadToEnd();
+
+                    //Modify the response in some way.
+                    if (context.Response.ContentType.Contains("application/json")
+                        || context.Response.ContentType.Contains("application/xml")
+                        || context.Response.ContentType.Contains("multipart/mixed"))
+                    {
+                        responseBody = responseBody
+                            .Replace("(____.", "(")
+                            .Replace("\"____.", "\"")
+                            .Replace("____.", ".")
+                            .Replace(" Namespace=\"____\"", " Namespace=\"\"");
+                    }
+
+                    using (var newStream = new MemoryStream())
+                    {
+                        var sw = new StreamWriter(newStream);
+                        sw.Write(responseBody);
+                        sw.Flush();
+
+                        newStream.Seek(0, SeekOrigin.Begin);
+
+                        await newStream.CopyToAsync(bodyStream);
+                    }
+                }
+                finally
+                {
+                    context.Response.Body = bodyStream;
+                }
             }
         }
     }

--- a/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataApplicationBuilderExtensions.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataApplicationBuilderExtensions.cs
@@ -66,9 +66,10 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
         /// <returns>Formed task.</returns>
         public static async Task RewriteResponse(HttpContext context, Func<Task> next)
         {
+            /* Same code for NETFRAMEWORK is placed on NewPlatform.Flexberry.ORM.ODataService.Handlers.PostPatchHandler.*/
             using (var responseBodyStream = new MemoryStream())
             {
-                var bodyStream = context.Response.Body;
+                Stream bodyStream = context.Response.Body;
 
                 try
                 {
@@ -77,7 +78,8 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
                     await next();
 
                     responseBodyStream.Seek(0, SeekOrigin.Begin);
-                    var responseBody = new StreamReader(responseBodyStream).ReadToEnd();
+                    using StreamReader sr = new StreamReader(responseBodyStream);
+                    var responseBody = sr.ReadToEnd();
 
                     //Modify the response in some way.
                     if (context.Response.ContentType != null &&
@@ -92,9 +94,9 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
                             .Replace(" Namespace=\"____\"", " Namespace=\"\"");
                     }
 
-                    using (var newStream = new MemoryStream())
+                    using (MemoryStream newStream = new MemoryStream())
                     {
-                        var sw = new StreamWriter(newStream);
+                        using StreamWriter sw = new StreamWriter(newStream);
                         sw.Write(responseBody);
                         sw.Flush();
 

--- a/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataApplicationBuilderExtensions.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataApplicationBuilderExtensions.cs
@@ -80,9 +80,10 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
                     var responseBody = new StreamReader(responseBodyStream).ReadToEnd();
 
                     //Modify the response in some way.
-                    if (context.Response.ContentType.Contains("application/json")
+                    if (context.Response.ContentType != null &&
+                        (context.Response.ContentType.Contains("application/json")
                         || context.Response.ContentType.Contains("application/xml")
-                        || context.Response.ContentType.Contains("multipart/mixed"))
+                        || context.Response.ContentType.Contains("multipart/mixed")))
                     {
                         responseBody = responseBody
                             .Replace("(____.", "(")

--- a/NewPlatform.Flexberry.ORM.ODataService/Handlers/PostPatchHandler.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Handlers/PostPatchHandler.cs
@@ -96,26 +96,27 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Handlers
             {
                 HttpContent content = response.Content;
                 Stream contentStream = await content.ReadAsStreamAsync();
-                using StreamReader sr = new StreamReader(contentStream);
-                string responseStr = sr.ReadToEnd();
-
-                responseStr = responseStr
+                string responseStr = new StreamReader(contentStream).ReadToEnd();
+                if (!string.IsNullOrEmpty(responseStr) && responseStr.Length > 3)
+                {
+                    responseStr = responseStr
                    .Replace("(____.", "(")
                    .Replace("\"____.", "\"")
                    .Replace("____.", ".")
                    .Replace(" Namespace=\"____\"", " Namespace=\"\"");
 
-                using (MemoryStream newStream = new MemoryStream())
-                {
-                    using StreamWriter sw = new StreamWriter(newStream);
-                    sw.Write(responseStr);
-                    sw.Flush();
-                    newStream.Seek(0, SeekOrigin.Begin);
+                    using (MemoryStream newStream = new MemoryStream())
+                    {
+                        using StreamWriter sw = new StreamWriter(newStream);
+                        sw.Write(responseStr);
+                        sw.Flush();
+                        newStream.Seek(0, SeekOrigin.Begin);
 
-                    contentStream.Position = 0;
-                    contentStream.SetLength(0);
+                        contentStream.Position = 0;
+                        contentStream.SetLength(responseStr.Length);
 
-                    await newStream.CopyToAsync(contentStream);
+                        await newStream.CopyToAsync(contentStream);
+                    }
                 }
             }
         }

--- a/NewPlatform.Flexberry.ORM.ODataService/Handlers/PostPatchHandler.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Handlers/PostPatchHandler.cs
@@ -1,6 +1,10 @@
 ﻿#if NETFRAMEWORK
 namespace NewPlatform.Flexberry.ORM.ODataService.Handlers
 {
+    using Microsoft.AspNet.OData.Batch;
+    using System;
+    using System.IO;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -33,8 +37,13 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Handlers
         public const string AcceptApplicationMsExcel = "PostPatchHandler_AcceptApplicationMsExcel";
 
         /// <inheritdoc/>
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
             foreach (var val in request.Headers.Accept)
             {
                 if (val.MediaType == "application/ms-excel")
@@ -64,7 +73,51 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Handlers
             if (!request.Headers.Contains("Accept-Charset"))
                 request.Headers.Add("Accept-Charset", new[] { "utf-8" });
 
-            return base.SendAsync(request, cancellationToken);
+            HttpResponseMessage responseMessage = await base.SendAsync(request, cancellationToken);
+            await RewriteResponse(responseMessage);
+            return responseMessage;
+
+        }
+
+        /// <summary>
+        /// Удаление некорректных символов в именах типов метаданных.
+        /// Данные символы добавляются специально, чтобы MS не бросало исключение на пустой Namespace у типов с PublishName.
+        /// </summary>
+        /// <param name="response">Текущее ответное сообщение, в котором могут быть заменены символы.</param>
+        /// <returns>Задача на обработку.</returns>
+        private static async Task RewriteResponse(HttpResponseMessage response)
+        {
+            /* Same code for NETSTANDARD is placed on NewPlatform.Flexberry.ORM.ODataService.Extensions.ODataApplicationBuilderExtensions.*/
+            string contentType = response?.Content?.Headers?.ContentType?.MediaType;
+            if (!string.IsNullOrEmpty(contentType) &&
+            (contentType.Contains("application/json")
+            || contentType.Contains("application/xml")
+            || contentType.Contains("multipart/mixed")))
+            {
+                HttpContent content = response.Content;
+                Stream contentStream = await content.ReadAsStreamAsync();
+                using StreamReader sr = new StreamReader(contentStream);
+                string responseStr = sr.ReadToEnd();
+
+                responseStr = responseStr
+                   .Replace("(____.", "(")
+                   .Replace("\"____.", "\"")
+                   .Replace("____.", ".")
+                   .Replace(" Namespace=\"____\"", " Namespace=\"\"");
+
+                using (MemoryStream newStream = new MemoryStream())
+                {
+                    using StreamWriter sw = new StreamWriter(newStream);
+                    sw.Write(responseStr);
+                    sw.Flush();
+                    newStream.Seek(0, SeekOrigin.Begin);
+
+                    contentStream.Position = 0;
+                    contentStream.SetLength(0);
+
+                    await newStream.CopyToAsync(contentStream);
+                }
+            }
         }
     }
 }

--- a/NewPlatform.Flexberry.ORM.ODataService/Model/DataObjectEdmModel.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Model/DataObjectEdmModel.cs
@@ -153,10 +153,7 @@
                 else
                     _typeHierarchy[baseDataObjectType].Add(dataObjectType);
 
-                string nameSpace = GetEntityTypeNamespace(dataObjectType);
-                string typeName = GetEntityTypeName(dataObjectType);
-
-                var typeFullName = string.IsNullOrEmpty(nameSpace) ? typeName : $"{nameSpace}.{typeName}";
+                var typeFullName = $"{GetEntityTypeNamespace(dataObjectType)}.{GetEntityTypeName(dataObjectType)}";
                 if (!_aliasesNameToProperty.ContainsKey(typeFullName))
                 {
                     _aliasesNameToProperty.Add(typeFullName, new Dictionary<string, PropertyInfo>());
@@ -724,7 +721,7 @@
             var nameSpace = GetEntityTypeNamespace(type);
             if (type != typeof(DataObject) && EdmModelBuilder != null && EdmModelBuilder.EntityTypeNameBuilder != null)
                 name = EdmModelBuilder.EntityTypeNameBuilder(type);
-            var fullname = string.IsNullOrEmpty(nameSpace) ? name : $"{nameSpace}.{name}";
+            var fullname = $"{nameSpace}.{name}";
             if (!_aliasesNameToType.ContainsKey(fullname))
                 _aliasesNameToType.Add(fullname, type);
             if (!_aliasesTypeToName.ContainsKey(type))
@@ -762,9 +759,7 @@
             var name = prop.Name;
             if (name != KeyPropertyName && prop.DeclaringType != typeof(DataObject) && EdmModelBuilder != null && EdmModelBuilder.EntityPropertyNameBuilder != null)
                 name = EdmModelBuilder.EntityPropertyNameBuilder(prop);
-            string nameSpace = GetEntityTypeNamespace(prop.DeclaringType);
-            string typeName = GetEntityTypeName(prop.DeclaringType);
-            string typeFullName = string.IsNullOrEmpty(nameSpace) ? typeName : $"{nameSpace}.{typeName}";
+            var typeFullName = $"{GetEntityTypeNamespace(prop.DeclaringType)}.{GetEntityTypeName(prop.DeclaringType)}";
             if (!_aliasesNameToProperty.ContainsKey(typeFullName))
             {
                 _aliasesNameToProperty.Add(typeFullName, new Dictionary<string, PropertyInfo>());

--- a/NewPlatform.Flexberry.ORM.ODataService/Model/DefaultDataObjectEdmModelBuilder.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Model/DefaultDataObjectEdmModelBuilder.cs
@@ -324,8 +324,7 @@
 
             string typeName = BuildEntityTypeName(dataObjectType);
             string nameSpace = BuildEntityTypeNamespace(dataObjectType);
-            return string.Concat((_useNamespaceInEntitySetName && !string.IsNullOrEmpty(nameSpace)) ? $"{nameSpace}.{typeName}".Replace(".", string.Empty) : typeName, "s"/* "Aliases"*/).Replace("_", string.Empty);
-            //return string.Concat(_useNamespaceInEntitySetName ? dataObjectType.FullName.Replace(".", string.Empty) : dataObjectType.Name, "s"/* "Aliases"*/).Replace("_", string.Empty);
+            return string.Concat(_useNamespaceInEntitySetName ? $"{nameSpace}.{typeName}".Replace(".", string.Empty) : typeName, "s"/* "Aliases"*/).Replace("_", string.Empty);
         }
 
         /// <summary>

--- a/NewPlatform.Flexberry.ORM.ODataService/Model/DefaultDataObjectEdmModelBuilder.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Model/DefaultDataObjectEdmModelBuilder.cs
@@ -324,7 +324,7 @@
 
             string typeName = BuildEntityTypeName(dataObjectType);
             string nameSpace = BuildEntityTypeNamespace(dataObjectType);
-            return string.Concat(_useNamespaceInEntitySetName ? $"{nameSpace}.{typeName}".Replace(".", string.Empty) : typeName, "s"/* "Aliases"*/).Replace("_", string.Empty);
+            return string.Concat(_useNamespaceInEntitySetName ? $"{nameSpace}.{typeName}".Replace(".", string.Empty) : typeName, "s").Replace("_", string.Empty);
         }
 
         /// <summary>

--- a/NewPlatform.Flexberry.ORM.ODataService/NewPlatform.Flexberry.ORM.ODataService.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService/NewPlatform.Flexberry.ORM.ODataService.csproj
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.LockService" Version="3.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataServiceCore.Common/NewPlatform.Flexberry.ORM.ODataServiceCore.Common.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataServiceCore.Common/NewPlatform.Flexberry.ORM.ODataServiceCore.Common.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
   </ItemGroup>
 
 </Project>

--- a/Tests/BusinessServers/NewPlatform.Flexberry.ORM.ODataService.Tests.BusinessServers.csproj
+++ b/Tests/BusinessServers/NewPlatform.Flexberry.ORM.ODataService.Tests.BusinessServers.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1-beta01" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/GetTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/GetTest.cs
@@ -1,0 +1,108 @@
+﻿namespace NewPlatform.Flexberry.ORM.ODataService.Tests.CRUD.Read
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http;
+
+    using ICSSoft.STORMNET;
+    using ICSSoft.STORMNET.UserDataTypes;
+    using ICSSoft.STORMNET.Windows.Forms;
+
+    using NewPlatform.Flexberry.ORM.ODataService.Tests.Extensions;
+
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    using Xunit;
+
+    /// <summary>
+    /// Класс тестов для проверки корректной обработки Get-запросов.
+    /// </summary>
+    public class GetTest : BaseODataServiceIntegratedTest
+    {
+#if NETCOREAPP
+        /// <summary>
+        /// Конструктор по-умолчанию.
+        /// </summary>
+        /// <param name="factory">Фабрика для приложения.</param>
+        /// <param name="output">Вывод отладочной информации.</param>
+        public GetTest(CustomWebApplicationFactory<ODataServiceSample.AspNetCore.Startup> factory, Xunit.Abstractions.ITestOutputHelper output)
+            : base(factory, output)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Проверка получения данных для классов, в которых есть нехранимые поля, который не содержат setter'ов.
+        /// (Такие варианты присутствуют в старом коде).
+        /// </summary>
+        [Fact]
+        public void TestGetNotStored()
+        {
+            ActODataService(args =>
+            {
+                LegoBlock block = new LegoBlock { Name = "Легосити" };
+                var objs = new DataObject[] { block };
+                args.DataService.UpdateObjects(ref objs);
+
+                string requestUrl = string.Format(
+                    "http://localhost/odata/{0}?$select=__PrimaryKey,AssocType",
+                    args.Token.Model.GetEdmEntitySet(typeof(LegoBlock)).Name);
+
+                // Обращаемся к OData-сервису и обрабатываем ответ.
+                using (HttpResponseMessage response = args.HttpClient.GetAsync(requestUrl).Result)
+                {
+                    // Убедимся, что запрос завершился успешно.
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    // Получим строку с ответом.
+                    string receivedStr = response.Content.ReadAsStringAsync().Result.Beautify();
+
+                    // Преобразуем полученный объект в словарь.
+                    Dictionary<string, object> receivedDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(receivedStr);
+
+                    Assert.Equal(1, ((JArray)receivedDict["value"]).Count);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Проверка значение в атрибуте @odata.type.
+        /// </summary>
+        [Fact]
+        public void TestGetWithMaster()
+        {
+            ActODataService(args =>
+            {
+                LegoBlock block = new LegoBlock { Name = "Легосити" };
+                LegoPatent patent = new LegoPatent { Name = "ZeroM", BaseLegoBlock = block };
+                var objs = new DataObject[] { block, patent };
+                args.DataService.UpdateObjects(ref objs);
+
+                string requestUrl = string.Format(
+                    "http://localhost/odata/{0}?$select=__PrimaryKey,Name&$expand=BaseLegoBlock($select=__PrimaryKey,Name)",
+                    args.Token.Model.GetEdmEntitySet(typeof(LegoPatent)).Name);
+
+                // Обращаемся к OData-сервису и обрабатываем ответ.
+                using (HttpResponseMessage response = args.HttpClient.GetAsync(requestUrl).Result)
+                {
+                    // Убедимся, что запрос завершился успешно.
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    // Получим строку с ответом.
+                    string receivedStr = response.Content.ReadAsStringAsync().Result.Beautify();
+
+                    // Преобразуем полученный объект в словарь.
+                    Dictionary<string, object> receivedDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(receivedStr);
+
+                    Assert.Equal(1, ((JArray)receivedDict["value"]).Count);
+                    Assert.Contains("@odata.type", receivedStr);
+#if NETCOREAPP
+                    Assert.DoesNotContain("____", receivedStr);
+#endif
+                }
+            });
+        }
+    }
+}

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/GetTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/GetTest.cs
@@ -98,9 +98,7 @@
 
                     Assert.Equal(1, ((JArray)receivedDict["value"]).Count);
                     Assert.Contains("@odata.type", receivedStr);
-#if NETCOREAPP
                     Assert.DoesNotContain("____", receivedStr);
-#endif
                 }
             });
         }

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/GetTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/GetTest.cs
@@ -76,7 +76,7 @@
             ActODataService(args =>
             {
                 LegoBlock block = new LegoBlock { Name = "Легосити" };
-                LegoPatent patent = new LegoPatent { Name = "ZeroM", BaseLegoBlock = block };
+                LegoPatent patent = new LegoPatent { Name = "ZeroM", BaseLegoBlock = block, Date = DateTime.Now };
                 var objs = new DataObject[] { block, patent };
                 args.DataService.UpdateObjects(ref objs);
 

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/MetaDataTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/MetaDataTest.cs
@@ -98,9 +98,7 @@
 
                     Assert.True(!string.IsNullOrEmpty(receivedData));
                     Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", receivedData);
-#if NETCOREAPP
                     Assert.DoesNotContain("____", receivedData);
-#endif
                 }
             });
         }

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/MetaDataTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/MetaDataTest.cs
@@ -98,6 +98,9 @@
 
                     Assert.True(!string.IsNullOrEmpty(receivedData));
                     Assert.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>", receivedData);
+#if NETCOREAPP
+                    Assert.DoesNotContain("____", receivedData);
+#endif
                 }
             });
         }

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
@@ -40,9 +40,9 @@
     <PackageReference Include="NewPlatform.Flexberry.Audit" Version="4.0.0" />
     <PackageReference Include="NewPlatform.Flexberry.ORM.GisMSSQLDataService" Version="2.0.0" />
     <PackageReference Include="NewPlatform.Flexberry.ORM.GisPostgresDataService" Version="2.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1-beta01" />
     <PackageReference Include="NewPlatform.Flexberry.Reports.ExportToExcel" Version="2.0.0" />
     <PackageReference Include="NewPlatform.Flexberry.Security" Version="3.0.0" />
   </ItemGroup>

--- a/Tests/Objects/BaseLegoBlock.cs
+++ b/Tests/Objects/BaseLegoBlock.cs
@@ -39,12 +39,20 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
         private NewPlatform.Flexberry.ORM.ODataService.Tests.LegoBlockColor fColor;
         
         private NewPlatform.Flexberry.ORM.ODataService.Tests.DetailArrayOfLegoPatent fPatents;
-        
+
         // *** Start programmer edit section *** (BaseLegoBlock CustomMembers)
 
+        [NotStored]
+        public virtual string AssocType
+        {
+            get
+            {
+                return GetType().Name;
+            }
+        }
         // *** End programmer edit section *** (BaseLegoBlock CustomMembers)
 
-        
+
         /// <summary>
         /// Name.
         /// </summary>

--- a/Tests/Objects/LegoBlock.cs
+++ b/Tests/Objects/LegoBlock.cs
@@ -48,12 +48,22 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
         private NewPlatform.Flexberry.ORM.ODataService.Tests.DetailArrayOfLegoBlockCustomPanel fCustomPanels;
         
         private NewPlatform.Flexberry.ORM.ODataService.Tests.DetailArrayOfLegoBlockTopPanel fTopPanels;
-        
+
         // *** Start programmer edit section *** (LegoBlock CustomMembers)
+
+        [NotStored]
+        [DataServiceExpression(typeof(ICSSoft.STORMNET.Business.PostgresDataService), "'Association'")]
+        public override string AssocType
+        {
+            get
+            {
+                return base.AssocType;
+            }
+        }
 
         // *** End programmer edit section *** (LegoBlock CustomMembers)
 
-        
+
         /// <summary>
         /// Width.
         /// </summary>

--- a/Tests/Objects/NewPlatform.Flexberry.ORM.ODataService.Tests.Objects.csproj
+++ b/Tests/Objects/NewPlatform.Flexberry.ORM.ODataService.Tests.Objects.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1-beta01" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/Objects/Медведь.cs
+++ b/Tests/Objects/Медведь.cs
@@ -326,6 +326,8 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
         [StrLen(255)]
         [DataServiceExpression(typeof(ICSSoft.STORMNET.Business.MSSQLDataService), "\'ПорядковыйНомер:\' + @ПорядковыйНомер@ + \", Цвет глаз мамы:\" + isnull(@Мама.ЦветГ" +
             "лаз@,\'\')")]
+        [DataServiceExpression(typeof(ICSSoft.STORMNET.Business.PostgresDataService), "\'ПорядковыйНомер:\' || @ПорядковыйНомер@ || \", Цвет глаз мамы:\" || coalesce(@Мама.ЦветГ" +
+            "лаз@,\'\')")]
         public virtual string МедведьСтрокой
         {
             get


### PR DESCRIPTION
Выявлено, что метаданные проявляют себя при наследовании. Если использовано PublishName, то теперь корректное возвращается имя типа в метаданных.

Также возвращён старый принцип формирования имени полного класса.

Добавлены тесты на выявленные проблемные места.