### PR TITLE
Changed version of NewPlatform.Flexberry.ORM.ODataService up to 7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
-1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1-beta01`.
+
+### Fixed
+
+## [7.1.1] - 2023.06.08
+
+### Added
+
+### Changed
+1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1`.
+2. Get properties from objects for send it to frontend always rethrow exception now.
 
 ### Fixed
 1. Fixed problem with metadata when inheritance and PublishName is used.
+2. Safe load details with complex type usage hierarchy.
 
 ## [7.1.0] - 2023.04.12
 

--- a/NewPlatform.Flexberry.ORM.ODataService.Files/NewPlatform.Flexberry.ORM.ODataService.Files.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService.Files/NewPlatform.Flexberry.ORM.ODataService.Files.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataService.WebApi/NewPlatform.Flexberry.ORM.ODataService.WebApi.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService.WebApi/NewPlatform.Flexberry.ORM.ODataService.WebApi.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.LockService" Version="3.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ODataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.ODataService</id>
-    <version>7.1.1-beta03</version>
+    <version>7.1.1</version>
     <title>Flexberry ORM ODataService</title>
     <authors>New Platform Ltd.</authors>
     <owners>New Platform Ltd.</owners>
@@ -13,7 +13,7 @@
     <description>Flexberry ORM OData Service Package.</description>
     <releaseNotes>
 		Changed
-		1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1-beta01`.
+		1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1`.
     2. Get properties from objects for send it to frontend always rethrow exception now.
 
 		Fixed

--- a/NewPlatform.Flexberry.ORM.ODataService/NewPlatform.Flexberry.ORM.ODataService.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService/NewPlatform.Flexberry.ORM.ODataService.csproj
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.LockService" Version="3.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataServiceCore.Common/NewPlatform.Flexberry.ORM.ODataServiceCore.Common.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataServiceCore.Common/NewPlatform.Flexberry.ORM.ODataServiceCore.Common.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Tests/BusinessServers/NewPlatform.Flexberry.ORM.ODataService.Tests.BusinessServers.csproj
+++ b/Tests/BusinessServers/NewPlatform.Flexberry.ORM.ODataService.Tests.BusinessServers.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
@@ -38,11 +38,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.Audit" Version="4.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.GisMSSQLDataService" Version="2.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.GisPostgresDataService" Version="2.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.GisMSSQLDataService" Version="2.1.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.GisPostgresDataService" Version="2.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1" />
     <PackageReference Include="NewPlatform.Flexberry.Reports.ExportToExcel" Version="2.0.0" />
     <PackageReference Include="NewPlatform.Flexberry.Security" Version="3.0.0" />
   </ItemGroup>

--- a/Tests/Objects/NewPlatform.Flexberry.ORM.ODataService.Tests.Objects.csproj
+++ b/Tests/Objects/NewPlatform.Flexberry.ORM.ODataService.Tests.Objects.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.1.1" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## [7.1.1] - 2023.06.08

### Added

### Changed
1. Updated `NewPlatform.Flexberry.ORM` up to `7.1.1`.
2. Get properties from objects for send it to frontend always rethrow exception now.

### Fixed
1. Fixed problem with metadata when inheritance and PublishName is used.
2. Safe load details with complex type usage hierarchy.