### PR TITLE
Feature release 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Flexberry ORM ODataService Changelog
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
-
 ## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+## [7.2.0] - 2024.03.27
 
 ### Added
 1. `updateViews` parameter of `DefaultDataObjectEdmModelBuilder` class. It allows to change update views for data objects (update view is used for loading a data object during OData update requests).
 
 ### Changed
-1. Updated Flexberry ORM up to 7.2.0-beta01.
+1. Updated Flexberry ORM up to 7.2.0.
 
 ### Fixed
 1. Fixed loading of object with crushing of already loaded masters.

--- a/NewPlatform.Flexberry.ORM.ODataService.Files/NewPlatform.Flexberry.ORM.ODataService.Files.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService.Files/NewPlatform.Flexberry.ORM.ODataService.Files.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataService.WebApi/NewPlatform.Flexberry.ORM.ODataService.WebApi.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService.WebApi/NewPlatform.Flexberry.ORM.ODataService.WebApi.csproj
@@ -22,7 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.LockService" Version="3.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ODataService.nuspec
@@ -16,13 +16,13 @@
     1. `updateViews` parameter of `DefaultDataObjectEdmModelBuilder` class. It allows to change update views for data objects (update view is used for loading a data object during OData update requests).
 
     Changed
-		1. Updated Flexberry ORM up to 7.2.0-beta01.
+		1. Updated Flexberry ORM up to 7.2.0.
 
 		Fixed
 		1. Fixed loading of object with crushing of already loaded masters.
 		2. Fixed loading of details.
 	</releaseNotes>
-    <copyright>Copyright New Platform Ltd 2023</copyright>
+    <copyright>Copyright New Platform Ltd 2024</copyright>
     <tags>Flexberry ORM OData ODataService</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
@@ -33,25 +33,25 @@
         <dependency id="Microsoft.OData.Edm" version="7.10.0" />
         <dependency id="Microsoft.Spatial" version="7.10.0" />
         <dependency id="NewPlatform.Flexberry.LockService" version="3.0.0" />
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
         <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="NewPlatform.Flexberry.AspNetCore.OData" version="7.6.2" />
         <dependency id="NewPlatform.Flexberry.LockService" version="3.0.0" />
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
         <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
       <group targetFramework=".NETCoreApp3.1">
         <dependency id="NewPlatform.Flexberry.AspNetCore.OData" version="7.6.2" />
         <dependency id="NewPlatform.Flexberry.LockService" version="3.0.0" />
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
         <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
         <group targetFramework=".NET6.0">
         <dependency id="NewPlatform.Flexberry.AspNetCore.OData" version="7.6.2" />
         <dependency id="NewPlatform.Flexberry.LockService" version="3.0.0" />
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
         <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
       <group targetFramework=".NET7.0">

--- a/NewPlatform.Flexberry.ORM.ODataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ODataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.ODataService</id>
-    <version>7.2.0-beta02</version>
+    <version>7.2.0</version>
     <title>Flexberry ORM ODataService</title>
     <authors>New Platform Ltd.</authors>
     <owners>New Platform Ltd.</owners>
@@ -13,9 +13,9 @@
     <description>Flexberry ORM OData Service Package.</description>
     <releaseNotes>
 		Added
-    1. `updateViews` parameter of `DefaultDataObjectEdmModelBuilder` class. It allows to change update views for data objects (update view is used for loading a data object during OData update requests).
+        1. `updateViews` parameter of `DefaultDataObjectEdmModelBuilder` class. It allows to change update views for data objects (update view is used for loading a data object during OData update requests).
 
-    Changed
+        Changed
 		1. Updated Flexberry ORM up to 7.2.0.
 
 		Fixed
@@ -57,7 +57,7 @@
       <group targetFramework=".NET7.0">
         <dependency id="NewPlatform.Flexberry.AspNetCore.OData" version="7.6.2" />
         <dependency id="NewPlatform.Flexberry.LockService" version="3.0.0" />
-        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0-beta01" />
+        <dependency id="NewPlatform.Flexberry.ORM" version="7.2.0" />
         <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
     </dependencies>

--- a/NewPlatform.Flexberry.ORM.ODataService/NewPlatform.Flexberry.ORM.ODataService.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataService/NewPlatform.Flexberry.ORM.ODataService.csproj
@@ -26,7 +26,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NewPlatform.Flexberry.LockService" Version="3.0.0" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NewPlatform.Flexberry.ORM.ODataServiceCore.Common/NewPlatform.Flexberry.ORM.ODataServiceCore.Common.csproj
+++ b/NewPlatform.Flexberry.ORM.ODataServiceCore.Common/NewPlatform.Flexberry.ORM.ODataServiceCore.Common.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Tests/BusinessServers/NewPlatform.Flexberry.ORM.ODataService.Tests.BusinessServers.csproj
+++ b/Tests/BusinessServers/NewPlatform.Flexberry.ORM.ODataService.Tests.BusinessServers.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.2.0-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.2.0-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.2.0-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.2.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.2.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
@@ -40,9 +40,9 @@
     <PackageReference Include="NewPlatform.Flexberry.Audit" Version="4.0.0" />
     <PackageReference Include="NewPlatform.Flexberry.ORM.GisMSSQLDataService" Version="2.1.0" />
     <PackageReference Include="NewPlatform.Flexberry.ORM.GisPostgresDataService" Version="2.1.1" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.2.0-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.2.0-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.2.0-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.2.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.2.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.2.0" />
     <PackageReference Include="NewPlatform.Flexberry.Reports.ExportToExcel" Version="2.0.0" />
     <PackageReference Include="NewPlatform.Flexberry.Security" Version="3.0.0" />
   </ItemGroup>

--- a/Tests/Objects/NewPlatform.Flexberry.ORM.ODataService.Tests.Objects.csproj
+++ b/Tests/Objects/NewPlatform.Flexberry.ORM.ODataService.Tests.Objects.csproj
@@ -14,10 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.2.0-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.2.0-beta01" />
-    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.2.0-beta01" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM" Version="7.2.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.MSSQLDataService" Version="7.2.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.OracleDataService" Version="7.2.0" />
+    <PackageReference Include="NewPlatform.Flexberry.ORM.PostgresDataService" Version="7.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
### Added
1. `updateViews` parameter of `DefaultDataObjectEdmModelBuilder` class. It allows to change update views for data objects (update view is used for loading a data object during OData update requests).

### Changed
1. Updated Flexberry ORM up to 7.2.0.

### Fixed
1. Fixed loading of object with crushing of already loaded masters.
2. Fixed loading of details.