### PR TITLE
Проверка длины полученного запроса на бэкенде

### DIFF
--- a/NewPlatform.Flexberry.ORM.ODataService/Extensions/HttpConfigurationExtensions.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Extensions/HttpConfigurationExtensions.cs
@@ -124,6 +124,11 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
                 config.MessageHandlers.Add(new PostPatchHandler());
             }
 
+            if (config.MessageHandlers.FirstOrDefault(h => h is RequestSizeLimitHandler) == null)
+            {
+                config.MessageHandlers.Add(new RequestSizeLimitHandler());
+            }
+
             return token;
         }
 

--- a/NewPlatform.Flexberry.ORM.ODataService/Handlers/RequestSizeLimitHandler.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Handlers/RequestSizeLimitHandler.cs
@@ -1,0 +1,94 @@
+﻿namespace NewPlatform.Flexberry.ORM.ODataService.Handlers
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNet.OData.Batch;
+
+#if NETFRAMEWORK
+    /// <summary>
+    /// Определяет класс обработчика http-запроса (http request handler), который в случае, если данный запрос превышает
+    /// максимально допустимую длину, то выбрасывается исключение:
+    /// HttpStatusCode.RequestEntityTooLarge. Работает для .NET Framework.
+    /// </summary>
+    public class RequestSizeLimitHandler : DelegatingHandler
+    {
+        public const long MaxRequestSize = 20 * 1024 * 1024; // TODO сделать считывание из конфига
+
+        /// <inheritdoc/>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+           var checkResult = CheckRequestSize(request);
+
+           if (checkResult != null)
+                return checkResult;
+
+           return await base.SendAsync(request, cancellationToken);
+        }
+
+        /// <summary>
+        /// Проверяет Content-Length запроса и возвращает HttpResponseMessage,
+        /// если размер превышает лимит.
+        /// </summary>
+        protected virtual HttpResponseMessage CheckRequestSize(HttpRequestMessage request)
+        {
+            if (request?.Content?.Headers?.ContentLength == null)
+                return null;
+
+            long length = request.Content.Headers.ContentLength.Value;
+
+            if (length > MaxRequestSize)
+            {
+                return new HttpResponseMessage(HttpStatusCode.RequestEntityTooLarge)
+                {
+                    ReasonPhrase = $"Request length {length} exceeds maximum allowed request length {MaxRequestSize} bytes.",
+                };
+            }
+
+            return null;
+        }
+    }
+
+#else //NETCOREAPP
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    /// Middleware для проверки размера тела запроса в .NET Core.
+    /// </summary>
+    public class RequestSizeLimitMiddleware
+    {
+        private readonly RequestDelegate _next;
+        public const long MaxRequestSize = 20 * 1024 * 1024; // 20 МБ
+
+        public RequestSizeLimitMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            var request = context.Request;
+
+            // Проверяются только запросы с телом.
+            if (request.ContentLength.HasValue &&
+                (request.Method == HttpMethods.Post ||
+                 request.Method == HttpMethods.Put ||
+                 request.Method == HttpMethods.Patch))
+            {
+                if (request.ContentLength.Value > MaxRequestSize)
+                {
+                    context.Response.StatusCode = (int)HttpStatusCode.RequestEntityTooLarge;
+                    await context.Response.WriteAsync(
+                        $"Request length {request.ContentLength.Value} exceeds maximum allowed length {MaxRequestSize} bytes.");
+                    return;
+                }
+            }
+
+            await _next(context);
+        }
+    }
+#endif
+}

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Handlers/RequestSizeLimitTests.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Handlers/RequestSizeLimitTests.cs
@@ -1,0 +1,46 @@
+﻿#if NETCOREAPP
+namespace NewPlatform.Flexberry.ORM.ODataService.Tests.Handlers
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using NewPlatform.Flexberry.ORM.ODataService.Tests.Extensions;
+    using NewPlatform.Flexberry.ORM.ODataService.Tests.Helpers;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class RequestSizeLimitTests : BaseODataServiceIntegratedTest<TestStartup>
+    {
+        public RequestSizeLimitTests(CustomWebApplicationFactory<TestStartup> factory, ITestOutputHelper output)
+            : base(factory, output)
+        {
+        }
+
+        [Fact]
+        public void CheckMaxQueryLenTest()
+        {
+            ActODataService(async args =>
+            {
+                const long maxLength = 10 * 1024 * 1024; // 10 МБ
+                var tooLargeBody = new string('a', (int)(maxLength + 1024));
+
+                var request = new HttpRequestMessage(HttpMethod.Post, "odata/Медведь")
+                {
+                    Content = new StringContent(tooLargeBody),
+                };
+
+                request.Content.Headers.ContentLength = tooLargeBody.Length;
+
+                HttpResponseMessage message = await args.HttpClient.SendAsync(request);
+
+                Assert.Equal((HttpStatusCode)413, message.StatusCode);
+            });
+        }
+    }
+}
+#else //NETFRAMEWORK
+public class RequestSizeLimitTests
+{
+    
+}
+#endif

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Handlers/RequestSizeLimitTests.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Handlers/RequestSizeLimitTests.cs
@@ -9,20 +9,31 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests.Handlers
     using Xunit;
     using Xunit.Abstractions;
 
+    /// <summary>
+    /// Класс для проверки ограничения размеров запроса.
+    /// Реализация под NETCOREAPP через <see cref="RequestSizeLimitMiddleware"/>.
+    /// </summary>
     public class RequestSizeLimitTests : BaseODataServiceIntegratedTest<TestStartup>
     {
+        /// <summary>
+        /// Конструктор.
+        /// </summary>
         public RequestSizeLimitTests(CustomWebApplicationFactory<TestStartup> factory, ITestOutputHelper output)
             : base(factory, output)
         {
         }
 
+        /// <summary>
+        /// Проверяет, что middleware корректно отрабатывает и возвращает ошибку 413,
+        /// если запрос превышает максимально допустимый размер.
+        /// </summary>
         [Fact]
         public void CheckMaxQueryLenTest()
         {
             ActODataService(async args =>
             {
-                const long maxLength = 10 * 1024 * 1024; // 10 МБ
-                var tooLargeBody = new string('a', (int)(maxLength + 1024));
+                const long oversizedLength = NewPlatform.Flexberry.ORM.ODataService.Handlers.RequestSizeLimitMiddleware.MaxRequestSize + 1024;
+                var tooLargeBody = new string('a', (int)oversizedLength);
 
                 var request = new HttpRequestMessage(HttpMethod.Post, "odata/Медведь")
                 {

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/TestStartup.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/TestStartup.cs
@@ -2,6 +2,7 @@
 namespace NewPlatform.Flexberry.ORM.ODataService.Tests
 {
     using System;
+    using System.Net.Http;
     using ICSSoft.Services;
     using IIS.Caseberry.Logging.Objects;
     using Microsoft.AspNetCore.Builder;
@@ -11,6 +12,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
     using Microsoft.Extensions.DependencyInjection;
     using NewPlatform.Flexberry.ORM.ODataService;
     using NewPlatform.Flexberry.ORM.ODataService.Extensions;
+    using NewPlatform.Flexberry.ORM.ODataService.Handlers;
     using NewPlatform.Flexberry.ORM.ODataService.Model;
     using NewPlatform.Flexberry.ORM.ODataService.WebApi.Extensions;
     using NewPlatform.Flexberry.Services;
@@ -39,6 +41,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
             unityContainer.RegisterInstance(env);
 
             app.UseMiddleware<ExceptionMiddleware>();
+            app.UseMiddleware<NewPlatform.Flexberry.ORM.ODataService.Handlers.RequestSizeLimitMiddleware>();
 
             app.UseMvc(builder =>
             {


### PR DESCRIPTION
https://gitlab.neoplatform.ru/flexberry-data-tech/orm-odataservice-tech/-/issues/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Введена защита от слишком крупных HTTP-запросов: для POST/PUT/PATCH установлен лимит 20 МБ; превышающие запросы получают ответ 413 (Payload Too Large).

* **Тесты**
  * Добавлены тесты, подтверждающие отклонение запросов, превышающих максимальный размер.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->