### PR TITLE
Убран IServiceProvider из конструктора DefaultDataObjectEdmModelBuilder

### DIFF
--- a/NewPlatform.Flexberry.ORM.ODataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ODataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.ODataService</id>
-    <version>8.0.0-beta02</version>
+    <version>8.0.0-beta03</version>
     <title>Flexberry ORM ODataService</title>
     <authors>New Platform Ltd.</authors>
     <owners>New Platform Ltd.</owners>
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Flexberry ORM OData Service Package.</description>
     <releaseNotes>
-		Added
+	Added
     1. Helper class `DataObjectEdmModelDependencies` (it helps send named settings of Unity to class `DataObjectEdmModel`).
 
     Changed

--- a/NewPlatform.Flexberry.ORM.ODataService/DataObjectControllerActivator.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/DataObjectControllerActivator.cs
@@ -59,8 +59,8 @@ namespace NewPlatform.Flexberry.ORM.ODataService
         {
             // TODO: заменить DependencyResolver на IServiceProvider
             IDependencyResolver dependencyResolver = request.GetConfiguration().DependencyResolver;
-            IDataService dataService = (IDataService)dependencyResolver.GetService(typeof(IDataService));
-            IDataObjectFileAccessor fileAccessor = (IDataObjectFileAccessor)dependencyResolver.GetService(typeof(IDataObjectFileAccessor));
+            IDataService dataService = (IDataService)dependencyResolver.GetService(typeof(IDataService)) ?? throw new InvalidOperationException($"{nameof(IDataService)} is not registered in the dependency scope."); ;
+            IDataObjectFileAccessor fileAccessor = (IDataObjectFileAccessor)dependencyResolver.GetService(typeof(IDataObjectFileAccessor)) ?? throw new InvalidOperationException($"{nameof(IDataObjectFileAccessor)} is not registered in the dependency scope."); ;
 
             DataObjectCache dataObjectCache = GetDataObjectCache(request);
             ManagementToken token = (request.GetRouteData().Route as ODataRoute).GetManagementToken();

--- a/NewPlatform.Flexberry.ORM.ODataService/DataObjectControllerActivator.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/DataObjectControllerActivator.cs
@@ -60,7 +60,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService
             // TODO: заменить DependencyResolver на IServiceProvider
             IDependencyResolver dependencyResolver = request.GetConfiguration().DependencyResolver;
             IDataService dataService = (IDataService)dependencyResolver.GetService(typeof(IDataService)) ?? throw new InvalidOperationException($"{nameof(IDataService)} is not registered in the dependency scope."); ;
-            IDataObjectFileAccessor fileAccessor = (IDataObjectFileAccessor)dependencyResolver.GetService(typeof(IDataObjectFileAccessor)) ?? throw new InvalidOperationException($"{nameof(IDataObjectFileAccessor)} is not registered in the dependency scope."); ;
+            IDataObjectFileAccessor fileAccessor = (IDataObjectFileAccessor)dependencyResolver.GetService(typeof(IDataObjectFileAccessor)) ?? throw new InvalidOperationException($"{nameof(IDataObjectFileAccessor)} is not registered in the dependency scope.");
 
             DataObjectCache dataObjectCache = GetDataObjectCache(request);
             ManagementToken token = (request.GetRouteData().Route as ODataRoute).GetManagementToken();

--- a/NewPlatform.Flexberry.ORM.ODataService/Model/DataObjectEdmModel.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Model/DataObjectEdmModel.cs
@@ -89,8 +89,7 @@
         /// Initializes a new instance of the <see cref="DataObjectEdmModel"/> class.
         /// </summary>
         /// <param name="metadata">Metadata-container for building EDM model</param>
-        /// <param name="dependencies">A set of parameters that determine how the export works.
-        /// During the correction, DI were moved to a separate class.</param>
+        /// <param name="dependencies">A set of parameters that determine how the export works. During the correction, DI were moved to a separate class.</param>
         /// <param name="edmModelBuilder">Entity for building an EDM model. sharpened to work with <see cref="DataObject"/>.</param>
         public DataObjectEdmModel(
             DataObjectEdmMetadata metadata,

--- a/NewPlatform.Flexberry.ORM.ODataService/Model/DataObjectEdmModel.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Model/DataObjectEdmModel.cs
@@ -89,12 +89,12 @@
         /// Initializes a new instance of the <see cref="DataObjectEdmModel"/> class.
         /// </summary>
         /// <param name="metadata">Metadata-container for building EDM model</param>
-        /// <param name="dependencies">A set of parameters that determine how the export works. During the correction, DI were moved to a separate class.</param>
         /// <param name="edmModelBuilder">Entity for building an EDM model. sharpened to work with <see cref="DataObject"/>.</param>
+        /// <param name="dependencies">A set of parameters that determine how the export works. During the correction, DI were moved to a separate class.</param>
         public DataObjectEdmModel(
             DataObjectEdmMetadata metadata,
-            DataObjectEdmModelDependencies dependencies = null,
-            IDataObjectEdmModelBuilder edmModelBuilder = null)
+            IDataObjectEdmModelBuilder edmModelBuilder = null,
+            DataObjectEdmModelDependencies dependencies = null)
         {
             EdmModelBuilder = edmModelBuilder;
 

--- a/NewPlatform.Flexberry.ORM.ODataService/Model/DefaultDataObjectEdmModelBuilder.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Model/DefaultDataObjectEdmModelBuilder.cs
@@ -9,7 +9,6 @@
     using ICSSoft.STORMNET.KeyGen;
 
     using Microsoft.OData.Edm;
-    using Unity;
 
     /// <summary>
     /// Default implementation of <see cref="IDataObjectEdmModelBuilder"/>.
@@ -36,7 +35,7 @@
         /// <summary>
         /// Container for dependency injection.
         /// </summary>
-        private IServiceProvider _serviceProvider;
+        private DataObjectEdmModelDependencies _dataObjectEdmModelDependencies;
 
         /// <summary>
         /// Additional mapping of CLR type to edm primitive type. When it's required on the application side.
@@ -96,22 +95,22 @@
         /// Initializes a new instance of the <see cref="DefaultDataObjectEdmModelBuilder"/> class.
         /// </summary>
         /// <param name="searchAssemblies">The list of assemblies for searching types to expose.</param>
-        /// <param name="container">Unity container for resolving dependencies.</param>
+        /// <param name="dataObjectEdmModelDependencies">A set of parameters that determine how the export works. During the correction, DI were moved to a separate class.</param>
         /// <param name="useNamespaceInEntitySetName">Is need to add the whole type namespace for EDM entity set.</param>
         /// <param name="pseudoDetailDefinitions">A collection of pseudodetail links.</param>
         /// <param name="additionalMapping">Additional mapping of CLR type to edm primitive type.</param>
         public DefaultDataObjectEdmModelBuilder(
             IEnumerable<Assembly> searchAssemblies,
-            IServiceProvider serviceProvider,
             bool useNamespaceInEntitySetName = true,
             PseudoDetailDefinitions pseudoDetailDefinitions = null,
             Dictionary<Type, IEdmPrimitiveType> additionalMapping = null,
             IEnumerable<KeyValuePair<Type, View>> updateViews = null,
             IEnumerable<Type> masterLightLoadTypes = null,
-            bool masterLightLoadAllTypes = false)
+            bool masterLightLoadAllTypes = false,
+            DataObjectEdmModelDependencies dataObjectEdmModelDependencies = null)
         {
             _searchAssemblies = searchAssemblies ?? throw new ArgumentNullException(nameof(searchAssemblies), "Contract assertion not met: searchAssemblies != null");
-            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _dataObjectEdmModelDependencies = dataObjectEdmModelDependencies;
             _useNamespaceInEntitySetName = useNamespaceInEntitySetName;
             _pseudoDetailDefinitions = pseudoDetailDefinitions ?? new PseudoDetailDefinitions();
 
@@ -187,9 +186,7 @@
                 }
             }
 
-            object fromProvider = _serviceProvider.GetService(typeof(DataObjectEdmModelDependencies));
-            var dataObjectEdmModel = new DataObjectEdmModel(meta, (DataObjectEdmModelDependencies)fromProvider, this);
-
+            DataObjectEdmModel dataObjectEdmModel = new DataObjectEdmModel(meta, _dataObjectEdmModelDependencies, this);
             return dataObjectEdmModel;
         }
 

--- a/NewPlatform.Flexberry.ORM.ODataService/Model/DefaultDataObjectEdmModelBuilder.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Model/DefaultDataObjectEdmModelBuilder.cs
@@ -186,7 +186,7 @@
                 }
             }
 
-            DataObjectEdmModel dataObjectEdmModel = new DataObjectEdmModel(meta, _dataObjectEdmModelDependencies, this);
+            DataObjectEdmModel dataObjectEdmModel = new DataObjectEdmModel(meta, this, _dataObjectEdmModelDependencies);
             return dataObjectEdmModel;
         }
 

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/BaseODataServiceIntegratedTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/BaseODataServiceIntegratedTest.cs
@@ -157,8 +157,8 @@
                     var fileAccessor = new DefaultDataObjectFileAccessor(new Uri("http://localhost/"), fileControllerPath, "Uploads");
                     container.RegisterInstance<IDataObjectFileAccessor>(fileAccessor);
 
-                    IServiceProvider serviceProvider = new ICSSoft.Services.UnityServiceProvider(container);
-                    DefaultDataObjectEdmModelBuilder builder = new DefaultDataObjectEdmModelBuilder(DataObjectsAssembliesNames, serviceProvider, UseNamespaceInEntitySetName, pseudoDetailDefinitions);
+                    DefaultDataObjectEdmModelBuilder builder = new DefaultDataObjectEdmModelBuilder(
+                        DataObjectsAssembliesNames, UseNamespaceInEntitySetName, pseudoDetailDefinitions, dataObjectEdmModelDependencies: container.Resolve<DataObjectEdmModelDependencies>());
                     var token = config.MapDataObjectRoute(builder, server, "odata", "odata", true);
                     token.Events.CallbackAfterInternalServerError = AfterInternalServerError;
                     var args = new TestArgs { UnityContainer = container, DataService = dataService, HttpClient = client, Token = token };

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Model/DefaultDataObjectModelBuilderTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Model/DefaultDataObjectModelBuilderTest.cs
@@ -32,7 +32,7 @@
             IServiceProvider serviceProvider = new UnityServiceProvider(unityContainer);
             unityContainer.RegisterInstance<DataObjectEdmModelDependencies>(null);
 
-            var builder = new DefaultDataObjectEdmModelBuilder(new[] { GetType().Assembly }, serviceProvider);
+            var builder = new DefaultDataObjectEdmModelBuilder(new[] { GetType().Assembly }, dataObjectEdmModelDependencies: null);
 
             DataObjectEdmModel model = builder.Build();
 

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Startup.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Startup.cs
@@ -137,7 +137,7 @@ namespace ODataServiceSample.AspNetCore
                     typeof(UserSetting).Assembly,
                     typeof(Lock).Assembly,
                 };
-                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, app.ApplicationServices, false);
+                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, false, dataObjectEdmModelDependencies: null);
 
                 var token = builder.MapDataObjectRoute(modelBuilder);
             });

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Startups/MasterLightLoadTestStartup.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Startups/MasterLightLoadTestStartup.cs
@@ -72,7 +72,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
 
                 // Set MasterLightLoad property for this DataObject
                 var masterLightLoadTypes = new List<Type> { typeof(Котенок) };
-                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, app.ApplicationServices, false, pseudoDetailDefinitions, masterLightLoadTypes: masterLightLoadTypes);
+                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, false, pseudoDetailDefinitions, masterLightLoadTypes: masterLightLoadTypes, dataObjectEdmModelDependencies: null);
 
                 var token = builder.MapDataObjectRoute(modelBuilder);
 

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Startups/UpdateViewsTestStartup.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Startups/UpdateViewsTestStartup.cs
@@ -66,7 +66,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
                     { typeof(Медведь), Медведь.Views.МедведьUpdateView },
                     { typeof(Берлога), Берлога.Views.БерлогаUpdateView },
                 };
-                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, serviceProvider, false, pseudoDetailDefinitions, updateViews: updateViews);
+                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, false, pseudoDetailDefinitions, updateViews: updateViews, dataObjectEdmModelDependencies: null);
 
                 var token = builder.MapDataObjectRoute(modelBuilder);
 

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/TestStartup.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/TestStartup.cs
@@ -17,6 +17,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
     using NewPlatform.Flexberry.Services;
     using ODataServiceSample.AspNetCore;
     using Unity;
+    using Unity.Injection;
 
     /// <summary>
     /// Startup for tests.
@@ -38,6 +39,14 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
             IServiceProvider serviceProvider = app.ApplicationServices;
             IUnityContainer unityContainer = serviceProvider.GetRequiredService<IUnityContainer>();
             unityContainer.RegisterInstance(env);
+            unityContainer.RegisterType<DataObjectEdmModelDependencies>(
+            new InjectionConstructor(
+                unityContainer.IsRegistered<IExportService>() ? unityContainer.Resolve<IExportService>() : null,
+                unityContainer.IsRegistered<IExportService>("Export") ? unityContainer.Resolve<IExportService>("Export") : null,
+                unityContainer.IsRegistered<IExportStringedObjectViewService>() ? unityContainer.Resolve<IExportStringedObjectViewService>() : null,
+                unityContainer.IsRegistered<IExportStringedObjectViewService>("ExportStringedObjectView") ? unityContainer.Resolve<IExportStringedObjectViewService>("ExportStringedObjectView") : null,
+                unityContainer.IsRegistered<IODataExportService>() ? unityContainer.Resolve<IODataExportService>() : null,
+                unityContainer.IsRegistered<IODataExportService>("Export") ? unityContainer.Resolve<IODataExportService>("Export") : null));
 
             app.UseMiddleware<ExceptionMiddleware>();
 
@@ -58,7 +67,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Tests
                 };
 
                 PseudoDetailDefinitions pseudoDetailDefinitions = (PseudoDetailDefinitions)serviceProvider.GetService(typeof(PseudoDetailDefinitions));
-                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, serviceProvider, false, pseudoDetailDefinitions);
+                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, false, pseudoDetailDefinitions, dataObjectEdmModelDependencies: unityContainer.Resolve<DataObjectEdmModelDependencies>());
 
                 var token = builder.MapDataObjectRoute(modelBuilder);
 


### PR DESCRIPTION
1. Изменена версия на 8.0.0-beta03
2. Новый параметр, добавленный при обновлении на DI в DefaultDataObjectEdmModelBuilder  был пересмотрен и отправлен в конец со значением по умолчанию.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Примечания к выпуску

* **Refactor**
  * Переработана передача зависимостей в EDM‑модели: заменён общий поставщик сервисов на явный объект зависимостей и изменён порядок параметров конструктора для более явной типизации.

* **Bug Fixes**
  * Улучшена проверка доступности сервисов при активации контроллера: при отсутствии сервиса теперь возникает явная ошибка.

* **Tests**
  * Обновлены стартапы и вызовы билдера в тестах под новую сигнатуру конструктора.

* **Chores**
  * Обновлён номер пакета до 8.0.0-beta03.

* **Documentation**
  * Актуализированы XML‑комментарии параметров.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->