### PR TITLE
Исправлена передача batch-квот для ODataBatchHandler

### DIFF
--- a/NewPlatform.Flexberry.ORM.ODataService.nuspec
+++ b/NewPlatform.Flexberry.ORM.ODataService.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>NewPlatform.Flexberry.ORM.ODataService</id>
-    <version>6.1.01-beta02</version>
+    <version>6.1.1-beta03</version>
     <title>Flexberry ORM ODataService</title>
     <authors>New Platform Ltd.</authors>
     <owners>New Platform Ltd.</owners>
@@ -12,8 +12,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Flexberry ORM OData Service Package.</description>
     <releaseNotes>
-      Added
-      1. Netstandard 2.0 implementation.
+      Fix custom OData batch quotas not being applied.
     </releaseNotes>
     <copyright>Copyright New Platform Ltd 2021</copyright>
     <tags>Flexberry ORM OData ODataService</tags>

--- a/NewPlatform.Flexberry.ORM.ODataService.sln
+++ b/NewPlatform.Flexberry.ORM.ODataService.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
+# Visual Studio Version 18
+VisualStudioVersion = 18.3.11520.95 d18.3
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewPlatform.Flexberry.ORM.ODataService", "NewPlatform.Flexberry.ORM.ODataService\NewPlatform.Flexberry.ORM.ODataService.csproj", "{01BBE45A-3A3F-4EA5-9457-8C62167B5E99}"
 EndProject
@@ -35,6 +35,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewPlatform.Flexberry.ORM.ODataServiceCore.Common", "NewPlatform.Flexberry.ORM.ODataServiceCore.Common\NewPlatform.Flexberry.ORM.ODataServiceCore.Common.csproj", "{2C84BB80-78BD-4771-BA5A-32D32DB568DE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NewPlatform.Flexberry.ORM.ODataServiceCore.WebApi", "NewPlatform.Flexberry.ORM.ODataServiceCore.WebApi\NewPlatform.Flexberry.ORM.ODataServiceCore.WebApi.csproj", "{B9E13B47-4A51-4D47-B5B1-2C1A3A8008B1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ODataServiceSample.AspNetCore", "Samples\ODataServiceSample.AspNetCore\ODataServiceSample.AspNetCore.csproj", "{28A780F7-6EB9-A237-835F-807BC99C829B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -74,6 +76,10 @@ Global
 		{B9E13B47-4A51-4D47-B5B1-2C1A3A8008B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B9E13B47-4A51-4D47-B5B1-2C1A3A8008B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B9E13B47-4A51-4D47-B5B1-2C1A3A8008B1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28A780F7-6EB9-A237-835F-807BC99C829B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28A780F7-6EB9-A237-835F-807BC99C829B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28A780F7-6EB9-A237-835F-807BC99C829B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28A780F7-6EB9-A237-835F-807BC99C829B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -84,7 +90,7 @@ Global
 		{BFB771C3-51D8-4804-BB0F-A0B4BD7981D9} = {A94D831A-7B5D-40C6-B76B-2B8B6335DB3E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {611B715C-AD46-45B1-BA4E-36C8F1A1896E}
 		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35;packages\Unity.Interception.2.1.505.0\lib\NET35;packages\EnterpriseLibrary.Common.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Data.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.5.0.505.0\lib\NET35;packages\EnterpriseLibrary.Logging.Database.5.0.505.0\lib\NET35
+		SolutionGuid = {611B715C-AD46-45B1-BA4E-36C8F1A1896E}
 	EndGlobalSection
 EndGlobal

--- a/NewPlatform.Flexberry.ORM.ODataService/Extensions/HttpConfigurationExtensions.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Extensions/HttpConfigurationExtensions.cs
@@ -108,6 +108,7 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
 
             // Token.
             ManagementToken token = route.CreateManagementToken(model);
+            token.BatchHandler = batchHandler;
 
             // Initialize events for batchHandler.
             batchHandler.InitializeEvents(token.Events);

--- a/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataRouteBuilderExtensions.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/Extensions/ODataRouteBuilderExtensions.cs
@@ -80,11 +80,20 @@ namespace NewPlatform.Flexberry.ORM.ODataService.Extensions
                 .AddService(ServiceLifetime.Singleton, typeof(IODataPathHandler), sp => new ExtendedODataPathHandler())
                 .AddService(ServiceLifetime.Singleton, typeof(IEnumerable<IODataRoutingConvention>), sp => DataObjectRoutingConventions.CreateDefault())
                 .AddService(ServiceLifetime.Singleton, typeof(ODataBatchHandler), sp => batchHandler)
+                .AddService(ServiceLifetime.Singleton, typeof(ODataMessageReaderSettings), sp =>
+                {
+                    var settings = new ODataMessageReaderSettings();
+                    settings.MessageQuotas.MaxPartsPerBatch = messageQuotasMaxPartsPerBatch;
+                    settings.MessageQuotas.MaxOperationsPerChangeset = messageQuotasMaxOperationsPerChangeset;
+                    settings.MessageQuotas.MaxReceivedMessageSize = messageQuotasMaxReceivedMessageSize;
+                    return settings;
+                })
                 .AddService(ServiceLifetime.Singleton, typeof(ODataSerializerProvider), sp => new CustomODataSerializerProvider(sp))
                 .AddService(ServiceLifetime.Singleton, typeof(ODataDeserializerProvider), sp => new ExtendedODataDeserializerProvider(sp)));
 
             // Token.
             ManagementToken token = route.CreateManagementToken(model);
+            token.BatchHandler = batchHandler;
 
             batchHandler.InitializeEvents(token.Events);
 

--- a/NewPlatform.Flexberry.ORM.ODataService/ManagementToken.cs
+++ b/NewPlatform.Flexberry.ORM.ODataService/ManagementToken.cs
@@ -1,6 +1,7 @@
-﻿namespace NewPlatform.Flexberry.ORM.ODataService
+namespace NewPlatform.Flexberry.ORM.ODataService
 {
     using System;
+    using Microsoft.AspNet.OData.Batch;
     using Microsoft.AspNet.OData.Routing;
 
     using NewPlatform.Flexberry.ORM.ODataService.Events;
@@ -47,6 +48,8 @@
         public IEventHandlerContainer Events { get; } = new EventHandlerContainer();
 
         public IFunctionContainer Functions { get; }
+
+        public ODataBatchHandler BatchHandler { get; internal set; }
 
         public ManagementToken(ODataRoute route, DataObjectEdmModel model)
         {

--- a/NewPlatform.Flexberry.ORM.ODataServiceCore/Extensions/ODataRouteBuilderExtensions.cs
+++ b/NewPlatform.Flexberry.ORM.ODataServiceCore/Extensions/ODataRouteBuilderExtensions.cs
@@ -63,16 +63,27 @@
             var applicationPartManager = builder.ServiceProvider.GetRequiredService<ApplicationPartManager>();
             applicationPartManager.ApplicationParts.Add(new AssemblyPart(typeof(DataObjectController).Assembly));
 
+            var batchHandler = new DataObjectODataBatchHandler();
+
             ODataRoute route = builder.MapODataServiceRoute(routeName, routePrefix, cb => cb
                 .AddService(ServiceLifetime.Singleton, typeof(IEdmModel), sp => model)
                 .AddService(ServiceLifetime.Singleton, typeof(IODataPathHandler), sp => new ExtendedODataPathHandler())
                 .AddService(ServiceLifetime.Singleton, typeof(IEnumerable<IODataRoutingConvention>), sp => DataObjectRoutingConventions.CreateDefault())
-                .AddService(ServiceLifetime.Singleton, typeof(ODataBatchHandler), sp => new DataObjectODataBatchHandler())
+                .AddService(ServiceLifetime.Singleton, typeof(ODataBatchHandler), sp => batchHandler)
+                .AddService(ServiceLifetime.Singleton, typeof(ODataMessageReaderSettings), sp =>
+                {
+                    var settings = new ODataMessageReaderSettings();
+                    settings.MessageQuotas.MaxPartsPerBatch = messageQuotasMaxPartsPerBatch;
+                    settings.MessageQuotas.MaxOperationsPerChangeset = messageQuotasMaxOperationsPerChangeset;
+                    settings.MessageQuotas.MaxReceivedMessageSize = messageQuotasMaxReceivedMessageSize;
+                    return settings;
+                })
                 .AddService(ServiceLifetime.Singleton, typeof(ODataSerializerProvider), sp => new CustomODataSerializerProvider(sp))
                 .AddService(ServiceLifetime.Singleton, typeof(ODataDeserializerProvider), sp => new ExtendedODataDeserializerProvider(sp)));
 
             // Token.
             ManagementToken token = route.CreateManagementToken(model);
+            token.BatchHandler = batchHandler;
 
             return token;
         }

--- a/NewPlatform.Flexberry.ORM.ODataServiceCore/ManagementToken.cs
+++ b/NewPlatform.Flexberry.ORM.ODataServiceCore/ManagementToken.cs
@@ -1,6 +1,7 @@
-﻿namespace NewPlatform.Flexberry.ORM.ODataService
+namespace NewPlatform.Flexberry.ORM.ODataService
 {
     using System;
+    using Microsoft.AspNet.OData.Batch;
     using Microsoft.AspNet.OData.Routing;
 
     using NewPlatform.Flexberry.ORM.ODataService.Events;
@@ -47,6 +48,8 @@
         public IEventHandlerContainer Events { get; } = new EventHandlerContainer();
 
         public IFunctionContainer Functions { get; }
+
+        public ODataBatchHandler BatchHandler { get; internal set; }
 
         public ManagementToken(ODataRoute route, DataObjectEdmModel model)
         {

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/App.config
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/App.config
@@ -6,7 +6,7 @@
   </configSections>
   <connectionStrings>
     <!-- Please set up your own database connection strings before you run integrated tests. -->
-    <add name="ConnectionStringPostgres" connectionString="SERVER=localhost;User ID=postgres;Password=postgres;Port=5439;" />
+    <add name="ConnectionStringPostgres" connectionString="SERVER=localhost;User ID=postgres;Password=p@ssw0rd;Port=5432;" />
     <add name="ConnectionStringOracle" connectionString="" />
     <add name="ConnectionStringMssql" connectionString="" />
     <add name="ConnectionStringLocalSqlServer" connectionString="Data Source=(LocalDb)\v11.0;" />

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/App.config
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/App.config
@@ -6,7 +6,7 @@
   </configSections>
   <connectionStrings>
     <!-- Please set up your own database connection strings before you run integrated tests. -->
-    <add name="ConnectionStringPostgres" connectionString="SERVER=localhost;User ID=postgres;Password=p@ssw0rd;Port=5432;" />
+    <add name="ConnectionStringPostgres" connectionString="SERVER=localhost;User ID=postgres;Password=postgres;Port=5439;" />
     <add name="ConnectionStringOracle" connectionString="" />
     <add name="ConnectionStringMssql" connectionString="" />
     <add name="ConnectionStringLocalSqlServer" connectionString="Data Source=(LocalDb)\v11.0;" />

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/BaseODataServiceIntegratedTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/BaseODataServiceIntegratedTest.cs
@@ -195,6 +195,11 @@
             return BatchHelper.CreateBatchRequest(url, changesets);
         }
 
+        protected HttpRequestMessage CreateBatchRequestWithMultipleTopLevelChangesets(string url, string[] changesets)
+        {
+            return BatchHelper.CreateBatchRequestWithMultipleTopLevelChangesets(url, changesets);
+        }
+
         /// <summary>
         /// Проверка наличия поддержки Gis текущей реализацией <see cref="IDataService"/>.
         /// </summary>

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/BatchOverrideQuotasTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/BatchOverrideQuotasTest.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using Xunit;
+
+namespace NewPlatform.Flexberry.ORM.ODataService.Tests.CRUD.Read
+{
+
+    /// <summary>
+    /// Тесты квот batch-запросов для кастомного QuotasStartup.
+    /// </summary>
+    public class BatchOverrideQuotasTest : BaseODataServiceIntegratedTest
+#if NETCOREAPP
+        , IClassFixture<QuotasCustomWebApplicationFactory>
+#endif
+    {
+#if NETCOREAPP
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchOverrideQuotasTest"/> class.
+        /// </summary>
+        /// <param name="factory">Фабрика для приложения.</param>
+        /// <param name="output">Вывод отладочной информации.</param>
+        public BatchOverrideQuotasTest(QuotasCustomWebApplicationFactory factory, Xunit.Abstractions.ITestOutputHelper output)
+            : base(factory, output)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Проверяет применение кастомных квот и успешную обработку batch между 1000 и 2000 операций.
+        /// </summary>
+        [Fact]
+        public void QuotasStartupShouldApplyOverrideAndAcceptBatchUpToTwoThousandOperations()
+        {
+            const int operationsInChangesetCount = 1500;
+
+            ActODataService(args =>
+            {
+                Assert.Equal(2000, args.Token.BatchHandler.MessageQuotas.MaxPartsPerBatch);
+                Assert.Equal(2000, args.Token.BatchHandler.MessageQuotas.MaxOperationsPerChangeset);
+                Assert.Equal(10485760 * 2, args.Token.BatchHandler.MessageQuotas.MaxReceivedMessageSize);
+
+                string baseUrl = "http://localhost/odata";
+                string countriesSetName = args.Token.Model.GetEdmEntitySet(typeof(Страна)).Name;
+                string[] changesets = Enumerable.Range(0, operationsInChangesetCount)
+                    .Select(_ => CreateChangeset(
+                        $"{baseUrl}/{countriesSetName}",
+                        "{}",
+                        new Страна()))
+                    .ToArray();
+
+                using (HttpRequestMessage request = CreateBatchRequest(baseUrl, changesets))
+                using (HttpResponseMessage response = args.HttpClient.SendAsync(request).Result)
+                {
+                    string responseBody = response.Content.ReadAsStringAsync().Result;
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Проверяет, что batch-запрос с количеством операций больше 2000 отклоняется в QuotasStartup.
+        /// </summary>
+        [Fact]
+        public void QuotasStartupShouldRejectBatchOverTwoThousandOperationsPerChangeset()
+        {
+            const int operationsInChangesetCount = 2001;
+
+            ActODataService(args =>
+            {
+                string baseUrl = "http://localhost/odata";
+                string countriesSetName = args.Token.Model.GetEdmEntitySet(typeof(Страна)).Name;
+                string[] changesets = Enumerable.Range(0, operationsInChangesetCount)
+                    .Select(_ => CreateChangeset(
+                        $"{baseUrl}/{countriesSetName}",
+                        "{}",
+                        new Страна()))
+                    .ToArray();
+
+                using (HttpRequestMessage request = CreateBatchRequest(baseUrl, changesets))
+                using (HttpResponseMessage response = args.HttpClient.SendAsync(request).Result)
+                {
+                    string responseBody = response.Content.ReadAsStringAsync().Result;
+
+                    Assert.False(response.IsSuccessStatusCode);
+                }
+            });
+        }
+
+    }
+}

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/BatchOverrideQuotasTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/BatchOverrideQuotasTest.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using Xunit;
-
-namespace NewPlatform.Flexberry.ORM.ODataService.Tests.CRUD.Read
+﻿namespace NewPlatform.Flexberry.ORM.ODataService.Tests.CRUD.Read
 {
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using Xunit;
 
     /// <summary>
     /// Тесты квот batch-запросов для кастомного QuotasStartup.

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/BatchQuotasTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/BatchQuotasTest.cs
@@ -1,0 +1,93 @@
+namespace NewPlatform.Flexberry.ORM.ODataService.Tests.CRUD.Read
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+
+    using Xunit;
+
+    /// <summary>
+    /// Тесты квот batch-запросов для стандартного Startup.
+    /// </summary>
+    public class BatchDefaultQuotasTest : BaseODataServiceIntegratedTest
+#if NETCOREAPP
+        , IClassFixture<CustomWebApplicationFactory<ODataServiceSample.AspNetCore.Startup>>
+#endif
+    {
+#if NETCOREAPP
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchDefaultQuotasTest"/> class.
+        /// </summary>
+        /// <param name="factory">Фабрика для приложения.</param>
+        /// <param name="output">Вывод отладочной информации.</param>
+        public BatchDefaultQuotasTest(CustomWebApplicationFactory<ODataServiceSample.AspNetCore.Startup> factory, Xunit.Abstractions.ITestOutputHelper output)
+            : base(factory, output)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Проверяет квоты по умолчанию (1000/1000/10485760) и успешную обработку batch > 100 операций.
+        /// </summary>
+        [Fact]
+        public void DefaultStartupShouldUseInternalQuotasAndAcceptBatchOverOneHundredOperations()
+        {
+            const int operationsInChangesetCount = 500;
+
+            ActODataService(args =>
+            {
+                Assert.Equal(1000, args.Token.BatchHandler.MessageQuotas.MaxPartsPerBatch);
+                Assert.Equal(1000, args.Token.BatchHandler.MessageQuotas.MaxOperationsPerChangeset);
+                Assert.Equal(10485760, args.Token.BatchHandler.MessageQuotas.MaxReceivedMessageSize);
+
+                string baseUrl = "http://localhost/odata";
+                string countriesSetName = args.Token.Model.GetEdmEntitySet(typeof(Страна)).Name;
+                string[] changesets = Enumerable.Range(0, operationsInChangesetCount)
+                    .Select(_ => CreateChangeset(
+                        $"{baseUrl}/{countriesSetName}",
+                        "{}",
+                        new Страна()))
+                    .ToArray();
+
+                using (HttpRequestMessage request = CreateBatchRequest(baseUrl, changesets))
+                using (HttpResponseMessage response = args.HttpClient.SendAsync(request).Result)
+                {
+                    string responseBody = response.Content.ReadAsStringAsync().Result;
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Проверяет, что batch-запрос с количеством операций больше 1000 отклоняется в стандартном Startup.
+        /// </summary>
+        [Fact]
+        public void DefaultStartupShouldRejectBatchOverThousandOperationsPerChangeset()
+        {
+            const int operationsInChangesetCount = 1001;
+
+            ActODataService(args =>
+            {
+                string baseUrl = "http://localhost/odata";
+                string countriesSetName = args.Token.Model.GetEdmEntitySet(typeof(Страна)).Name;
+                string[] changesets = Enumerable.Range(0, operationsInChangesetCount)
+                    .Select(_ => CreateChangeset(
+                        $"{baseUrl}/{countriesSetName}",
+                        "{}",
+                        new Страна()))
+                    .ToArray();
+
+                using (HttpRequestMessage request = CreateBatchRequest(baseUrl, changesets))
+                using (HttpResponseMessage response = args.HttpClient.SendAsync(request).Result)
+                {
+                    string responseBody = response.Content.ReadAsStringAsync().Result;
+
+                    Assert.False(response.IsSuccessStatusCode);
+                }
+            });
+        }
+
+    }
+}

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/BatchTopLevelPartsQuotaTest.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/CRUD/Read/BatchTopLevelPartsQuotaTest.cs
@@ -1,0 +1,88 @@
+namespace NewPlatform.Flexberry.ORM.ODataService.Tests.CRUD.Read
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+
+    using Xunit;
+
+    /// <summary>
+    /// Проверки квоты MaxPartsPerBatch на top-level parts.
+    /// </summary>
+    public class BatchTopLevelPartsQuotaTest : BaseODataServiceIntegratedTest
+#if NETCOREAPP
+        , IClassFixture<SmallPartsQuotasCustomWebApplicationFactory>
+#endif
+    {
+#if NETCOREAPP
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BatchTopLevelPartsQuotaTest"/> class.
+        /// </summary>
+        /// <param name="factory">Фабрика для приложения.</param>
+        /// <param name="output">Вывод отладочной информации.</param>
+        public BatchTopLevelPartsQuotaTest(SmallPartsQuotasCustomWebApplicationFactory factory, Xunit.Abstractions.ITestOutputHelper output)
+            : base(factory, output)
+        {
+        }
+#endif
+
+        /// <summary>
+        /// Проверяет, что batch с количеством top-level parts в пределах квоты обрабатывается успешно.
+        /// </summary>
+        [Fact]
+        public void SmallPartsQuotaStartupShouldAcceptBatchAtLimit()
+        {
+            const int topLevelPartsCount = 5;
+
+            ActODataService(args =>
+            {
+                Assert.Equal(5, args.Token.BatchHandler.MessageQuotas.MaxPartsPerBatch);
+
+                string baseUrl = "http://localhost/odata";
+                string countriesSetName = args.Token.Model.GetEdmEntitySet(typeof(Страна)).Name;
+                string[] changesets = Enumerable.Range(0, topLevelPartsCount)
+                    .Select(_ => CreateChangeset(
+                        $"{baseUrl}/{countriesSetName}",
+                        "{}",
+                        new Страна()))
+                    .ToArray();
+
+                using (HttpRequestMessage request = CreateBatchRequestWithMultipleTopLevelChangesets(baseUrl, changesets))
+                using (HttpResponseMessage response = args.HttpClient.SendAsync(request).Result)
+                {
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Проверяет, что batch с превышением top-level parts отклоняется.
+        /// </summary>
+        [Fact]
+        public void SmallPartsQuotaStartupShouldRejectBatchOverLimit()
+        {
+            const int topLevelPartsCount = 6;
+
+            ActODataService(args =>
+            {
+                string baseUrl = "http://localhost/odata";
+                string countriesSetName = args.Token.Model.GetEdmEntitySet(typeof(Страна)).Name;
+                string[] changesets = Enumerable.Range(0, topLevelPartsCount)
+                    .Select(_ => CreateChangeset(
+                        $"{baseUrl}/{countriesSetName}",
+                        "{}",
+                        new Страна()))
+                    .ToArray();
+
+                using (HttpRequestMessage request = CreateBatchRequestWithMultipleTopLevelChangesets(baseUrl, changesets))
+                using (HttpResponseMessage response = args.HttpClient.SendAsync(request).Result)
+                {
+                    string responseBody = response.Content.ReadAsStringAsync().Result;
+
+                    Assert.False(response.IsSuccessStatusCode);
+                }
+            });
+        }
+    }
+}

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Helpers/BatchHelper.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/Helpers/BatchHelper.cs
@@ -66,6 +66,30 @@
         }
 
         /// <summary>
+        /// Создать batch-запрос с несколькими top-level changeset частями.
+        /// </summary>
+        /// <param name="url">Базовый адрес odata-сервиса.</param>
+        /// <param name="changesets">Набор подзапросов (по одному на changeset).</param>
+        /// <returns>Сконфигурированный <see cref="HttpRequestMessage" /> содержащий batch-запрос.</returns>
+        public static HttpRequestMessage CreateBatchRequestWithMultipleTopLevelChangesets(string url, string[] changesets)
+        {
+            string boundary = $"batch_{Guid.NewGuid()}";
+            string body = CreateBatchBodyWithMultipleTopLevelChangesets(boundary, changesets);
+
+            var request = new HttpRequestMessage
+            {
+                RequestUri = new Uri($"{url}/$batch"),
+                Method = new HttpMethod("POST"),
+                Content = new StringContent(body),
+            };
+
+            request.Content.Headers.ContentType.MediaType = "multipart/mixed";
+            request.Content.Headers.ContentType.Parameters.Add(new NameValueHeaderValue("boundary", boundary));
+
+            return request;
+        }
+
+        /// <summary>
         /// Проверить ответ на batch-запрос.
         /// </summary>
         /// <param name="response">Сообщение.</param>
@@ -108,6 +132,33 @@
             }
 
             body.AppendLine($"--{changesetBoundary}--");
+            body.AppendLine($"--{boundary}--");
+            body.AppendLine();
+
+            return body.ToString();
+        }
+
+        private static string CreateBatchBodyWithMultipleTopLevelChangesets(string boundary, string[] changesets)
+        {
+            var body = new StringBuilder();
+
+            for (var i = 0; i < changesets.Length; i++)
+            {
+                string changesetBoundary = $"changeset_{Guid.NewGuid()}";
+
+                body.AppendLine($"--{boundary}");
+                body.AppendLine($"Content-Type: multipart/mixed;boundary={changesetBoundary}");
+                body.AppendLine();
+
+                body.AppendLine($"--{changesetBoundary}");
+                body.AppendLine("Content-Type: application/http");
+                body.AppendLine("Content-Transfer-Encoding: binary");
+                body.AppendLine($"Content-ID: {i + 1}");
+                body.AppendLine();
+                body.AppendLine(changesets[i]);
+                body.AppendLine($"--{changesetBoundary}--");
+            }
+
             body.AppendLine($"--{boundary}--");
             body.AppendLine();
 

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/NewPlatform.Flexberry.ORM.ODataService.Tests.csproj
@@ -106,7 +106,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <ProjectReference Include="..\..\NewPlatform.Flexberry.ORM.ODataServiceCore.WebApi\NewPlatform.Flexberry.ORM.ODataServiceCore.WebApi.csproj" />
-    <ProjectReference Include="..\..\Samples\ODataServiceSample.AspNetCore\ODataServiceSample.AspNetCore.csproj" />
+	<ProjectReference Include="..\..\Samples\ODataServiceSample.AspNetCore\ODataServiceSample.AspNetCore.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/QuotasCustomWebApplicationFactory.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/QuotasCustomWebApplicationFactory.cs
@@ -1,0 +1,28 @@
+#if NETCOREAPP
+namespace NewPlatform.Flexberry.ORM.ODataService.Tests
+{
+    using System.IO;
+    using ICSSoft.Services;
+    using Microsoft.AspNetCore.Hosting;
+    using ODataServiceSample.AspNetCore;
+    using Unity.Microsoft.DependencyInjection;
+
+    /// <summary>
+    /// Custom web application factory for batch quotas tests.
+    /// </summary>
+    public class QuotasCustomWebApplicationFactory : CustomWebApplicationFactory<Startup>
+    {
+        /// <inheritdoc/>
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            string contentRootDirectory = Directory.GetCurrentDirectory();
+            var container = UnityFactory.GetContainer();
+
+            return new WebHostBuilder()
+                .UseUnityServiceProvider(container)
+                .UseContentRoot(contentRootDirectory)
+                .UseStartup<QuotasTestStartup>();
+        }
+    }
+}
+#endif

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/QuotasTestStartup.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/QuotasTestStartup.cs
@@ -1,0 +1,72 @@
+#if NETCOREAPP
+namespace NewPlatform.Flexberry.ORM.ODataService.Tests
+{
+    using ICSSoft.Services;
+    using IIS.Caseberry.Logging.Objects;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.Configuration;
+    using NewPlatform.Flexberry.ORM.ODataService;
+    using NewPlatform.Flexberry.ORM.ODataService.Extensions;
+    using NewPlatform.Flexberry.ORM.ODataService.Model;
+    using NewPlatform.Flexberry.ORM.ODataService.WebApi.Extensions;
+    using NewPlatform.Flexberry.Services;
+    using ODataServiceSample.AspNetCore;
+    using Unity;
+
+    /// <summary>
+    /// Startup for batch quotas tests.
+    /// </summary>
+    public class QuotasTestStartup : Startup
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuotasTestStartup"/> class.
+        /// </summary>
+        /// <param name="configuration">Configuration for new instance.</param>
+        public QuotasTestStartup(IConfiguration configuration)
+            : base(configuration)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            IUnityContainer unityContainer = UnityFactory.GetContainer();
+            unityContainer.RegisterInstance(env);
+
+            app.UseMiddleware<ExceptionMiddleware>();
+
+            app.UseMvc(builder =>
+            {
+                builder.MapRoute("Lock", "api/lock/{action}/{dataObjectId}", new { controller = "Lock" });
+                builder.MapFileRoute();
+            });
+
+            app.UseODataService(builder =>
+            {
+                IUnityContainer container = UnityFactory.GetContainer();
+
+                var assemblies = new[]
+                {
+                    typeof(Медведь).Assembly,
+                    typeof(ApplicationLog).Assembly,
+                    typeof(UserSetting).Assembly,
+                    typeof(Lock).Assembly,
+                };
+
+                PseudoDetailDefinitions pseudoDetailDefinitions = (PseudoDetailDefinitions)container.Resolve(typeof(PseudoDetailDefinitions));
+                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, false, pseudoDetailDefinitions);
+
+                var token = builder.MapDataObjectRoute(
+                    modelBuilder,
+                    messageQuotasMaxPartsPerBatch: 2000,
+                    messageQuotasMaxOperationsPerChangeset: 2000,
+                    messageQuotasMaxReceivedMessageSize: 10485760 * 2);
+
+                container.RegisterInstance(typeof(ManagementToken), token);
+            });
+        }
+    }
+}
+#endif

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/SmallPartsQuotasCustomWebApplicationFactory.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/SmallPartsQuotasCustomWebApplicationFactory.cs
@@ -1,0 +1,28 @@
+#if NETCOREAPP
+namespace NewPlatform.Flexberry.ORM.ODataService.Tests
+{
+    using System.IO;
+    using ICSSoft.Services;
+    using Microsoft.AspNetCore.Hosting;
+    using ODataServiceSample.AspNetCore;
+    using Unity.Microsoft.DependencyInjection;
+
+    /// <summary>
+    /// Custom web application factory for small max-parts quota tests.
+    /// </summary>
+    public class SmallPartsQuotasCustomWebApplicationFactory : CustomWebApplicationFactory<Startup>
+    {
+        /// <inheritdoc/>
+        protected override IWebHostBuilder CreateWebHostBuilder()
+        {
+            string contentRootDirectory = Directory.GetCurrentDirectory();
+            var container = UnityFactory.GetContainer();
+
+            return new WebHostBuilder()
+                .UseUnityServiceProvider(container)
+                .UseContentRoot(contentRootDirectory)
+                .UseStartup<SmallPartsQuotasTestStartup>();
+        }
+    }
+}
+#endif

--- a/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/SmallPartsQuotasTestStartup.cs
+++ b/Tests/NewPlatform.Flexberry.ORM.ODataService.Tests/SmallPartsQuotasTestStartup.cs
@@ -1,0 +1,72 @@
+#if NETCOREAPP
+namespace NewPlatform.Flexberry.ORM.ODataService.Tests
+{
+    using ICSSoft.Services;
+    using IIS.Caseberry.Logging.Objects;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.Configuration;
+    using NewPlatform.Flexberry.ORM.ODataService;
+    using NewPlatform.Flexberry.ORM.ODataService.Extensions;
+    using NewPlatform.Flexberry.ORM.ODataService.Model;
+    using NewPlatform.Flexberry.ORM.ODataService.WebApi.Extensions;
+    using NewPlatform.Flexberry.Services;
+    using ODataServiceSample.AspNetCore;
+    using Unity;
+
+    /// <summary>
+    /// Startup for small max-parts batch quota tests.
+    /// </summary>
+    public class SmallPartsQuotasTestStartup : Startup
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SmallPartsQuotasTestStartup"/> class.
+        /// </summary>
+        /// <param name="configuration">Configuration for new instance.</param>
+        public SmallPartsQuotasTestStartup(IConfiguration configuration)
+            : base(configuration)
+        {
+        }
+
+        /// <inheritdoc/>
+        public override void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            IUnityContainer unityContainer = UnityFactory.GetContainer();
+            unityContainer.RegisterInstance(env);
+
+            app.UseMiddleware<ExceptionMiddleware>();
+
+            app.UseMvc(builder =>
+            {
+                builder.MapRoute("Lock", "api/lock/{action}/{dataObjectId}", new { controller = "Lock" });
+                builder.MapFileRoute();
+            });
+
+            app.UseODataService(builder =>
+            {
+                IUnityContainer container = UnityFactory.GetContainer();
+
+                var assemblies = new[]
+                {
+                    typeof(Медведь).Assembly,
+                    typeof(ApplicationLog).Assembly,
+                    typeof(UserSetting).Assembly,
+                    typeof(Lock).Assembly,
+                };
+
+                PseudoDetailDefinitions pseudoDetailDefinitions = (PseudoDetailDefinitions)container.Resolve(typeof(PseudoDetailDefinitions));
+                var modelBuilder = new DefaultDataObjectEdmModelBuilder(assemblies, false, pseudoDetailDefinitions);
+
+                var token = builder.MapDataObjectRoute(
+                    modelBuilder,
+                    messageQuotasMaxPartsPerBatch: 5,
+                    messageQuotasMaxOperationsPerChangeset: 2000,
+                    messageQuotasMaxReceivedMessageSize: 10485760 * 2);
+
+                container.RegisterInstance(typeof(ManagementToken), token);
+            });
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Исправлена причина ошибки `current batch message contains too many parts ... '100'`. 
- Квоты из MapDataObjectRoute(...) теперь корректно применяются
- Добавлена переменная ManagementToken.BatchHandler, чтобы обращаться к route-specific batch handler.
- Добавлены тесты batch-квот:
  - проверка дефолтных и кастомных лимитов;
  - отдельная проверка, что лимит `MaxPartsPerBatch` действительно применяется.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Примечания к выпуску

* **Исправления ошибок**
  * Исправлена проблема, при которой пользовательские квоты для пакетных запросов OData не применялись корректно.

* **Улучшения**
  * Улучшена обработка пакетных операций OData с правильным применением лимитов на количество операций и размер сообщений.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->